### PR TITLE
feat: adding release pipeline; updating README.md

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,99 @@
+name: Release Resource Pack
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'  # Trigger on semantic version tags like v1.2.3
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Needed for pushing changes and creating releases
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for changelog
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install Pillow numpy
+
+      - name: Fix transparent images
+        run: python clearPictureFixer.py
+        
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          # Parse version components
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f2)
+          PATCH=$(echo $VERSION | cut -d. -f3)
+          echo "major=$MAJOR" >> $GITHUB_OUTPUT
+          echo "minor=$MINOR" >> $GITHUB_OUTPUT
+          echo "patch=$PATCH" >> $GITHUB_OUTPUT
+
+      - name: Update version in manifest.json
+        run: |
+          jq '.header.version = [${{ steps.get_version.outputs.major }}, ${{ steps.get_version.outputs.minor }}, ${{ steps.get_version.outputs.patch }}] | .header.name = "BE_Tech_RP_v${{ steps.get_version.outputs.major }}.${{ steps.get_version.outputs.minor }}.${{ steps.get_version.outputs.patch }}"' manifest.json > manifest.json.tmp
+          mv manifest.json.tmp manifest.json
+
+      - name: Commit and push updated manifest.json
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add manifest.json
+          git commit -m "chore: update version to v${{ steps.get_version.outputs.version }} in manifest.json [skip ci]"
+          git push origin HEAD:${GITHUB_REF_NAME%%/*}
+
+      - name: Create .mcpack file
+        id: create_mcpack
+        run: |
+          MCPACK_NAME="Bedrock-Technical-Resource-Pack-v${{ steps.get_version.outputs.version }}.mcpack"
+          zip -r Bedrock-Technical-Resource-Pack-v${{ steps.get_version.outputs.version }}.zip ./* \
+            -x "*.git*" \
+            -x ".github/*" \
+            -x "*.md" \
+            -x "clearPictureFixer.py" \
+            -x "LICENSE"
+          mv Bedrock-Technical-Resource-Pack-v${{ steps.get_version.outputs.version }}.zip $MCPACK_NAME
+          echo "mcpack_path=$MCPACK_NAME" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            
+            // Read the mcpack file
+            const mcpackPath = '${{ steps.create_mcpack.outputs.mcpack_path }}';
+            const mcpackData = fs.readFileSync(mcpackPath);
+            
+            // Create the release with auto-generated notes
+            const { data: releaseData } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: context.ref.replace('refs/tags/', ''),
+              name: 'Release v${{ steps.get_version.outputs.version }}',
+              generate_release_notes: true
+            });
+            
+            // Upload the mcpack asset
+            await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: releaseData.id,
+              name: mcpackPath,
+              data: mcpackData
+            });

--- a/README.md
+++ b/README.md
@@ -1,4 +1,83 @@
-# Bedrock-Technical-Resource-Pack
- This pack contains visual repressentations for a large number of technical feauters in minecraft. Documentation for this pack is in a git hub wiki format.
- 
-[here is the link to the wiki](https://github.com/RavinMaddHatter/Bedrock-Technical-Resource-Pack/wiki)
+# Bedrock Technical Resource Pack
+
+Welcome to the Bedrock-Technical-Resource-Pack! This is a project that aims to provide tools to design and build farms in a survival/achievements enabled world.
+This means we are not using behavior packs, commands, or other items that the normal player on a typical server would not have access to. To do that we have to
+use an armor stand as an anchor for the tools as it is the only entity that can be placed on a single block and be switched manipulated. If a person can find a
+way to make the tridents or other AI-free entities host several geometries we are looking for contributions.
+
+## Overview
+
+This resource pack enhances the visual feedback for many technical aspects of Minecraft, including:
+
+- Hitbox visualization
+- Spawning area indicators
+- Redstone signal strength displays
+- Entity behavior indicators
+- And many more technical features
+
+By making these normally invisible or hard-to-see game mechanics visible, this pack is invaluable for technical players, redstone engineers, map makers, and anyone interested in understanding how Minecraft works under the hood.
+
+## Features
+
+- Visual indicators for mob spawning ranges
+- Enhanced armor stand functionality with special items
+- Technical block behavior visualization
+- Redstone signal strength indicators
+- Improved debugging capabilities for complex builds
+- Compatible with the latest Minecraft Bedrock Edition versions
+
+## Installation
+
+### Method 1: Using .mcpack File (Recommended)
+
+1. Download the latest `.mcpack` file from the [Releases page](https://github.com/RavinMaddHatter/Bedrock-Technical-Resource-Pack/releases)
+2. Open the `.mcpack` file with Minecraft Bedrock Edition
+3. The game will automatically import the resource pack
+4. Activate the pack in your game settings under "Resource Packs"
+
+### Method 2: Manual Installation
+
+1. Download the repository as a ZIP file
+2. Extract the contents into the following location depending on your platform:
+    - **Windows 10/11**: `%localappdata%\Packages\Microsoft.MinecraftUWP_8wekyb3d8bbwe\LocalState\games\com.mojang\resource_packs\`
+    - **iOS/Android**: `games/com.mojang/resource_packs/`
+    - **Nintendo Switch**: Import via USB connection or Realms
+3. Launch Minecraft and activate the pack in the game settings
+
+## How to Contribute
+
+Contributions to improve the resource pack are welcome! Here's how you can contribute:
+
+1. **Fork** the repository
+2. **Clone** your fork locally
+3. **Create a branch** for your feature or fix
+4. Make your changes
+5. Test your changes in Minecraft
+6. **Submit a pull request** with a clear description of your improvements
+
+### Development Guidelines
+
+- Follow Minecraft's texture format and structure
+- Use transparent images correctly (the repository has a script to fix common issues)
+- Test all changes in-game before submitting
+- Document any new features you add
+
+## Documentation
+
+Extensive documentation for this pack is available in the [GitHub Wiki](https://github.com/RavinMaddHatter/Bedrock-Technical-Resource-Pack/wiki).
+
+The wiki includes:
+
+- Detailed explanations of each visual indicator
+- How to use special items with armor stands
+- Technical block behavior guides
+- Troubleshooting tips
+
+## License
+
+Please see the LICENSE file for details on the usage and redistribution of this resource pack.
+
+---
+
+*This resource pack is not affiliated with Mojang or Microsoft.*
+*All rights to Minecraft and its assets are owned by Mojang Studios.*


### PR DESCRIPTION
Hi MaddHatter! I'm Igor, and I've been using your packs for a while now, and though I'm not a technical Minecraft player, I found a way to contribute to your work! I noticed that the last release got a weird tag, so I created an easy-to-use pipeline to generate the releases for you.

To make it work, you just need to push a new tag following SemVer:

```bash
git tag v0.2.9
git push origin v0.2.9
```

Then the pipeline will trigger automatically. It will:

- Run that Python script to fix the image's transparency;
- Bump the version inside the `manifest.json` file (and commit it);
- Generate the Release page with all the changes and attach the `.mcpack` file to it.

> [!NOTE]  
> I did it this way, so you are free to choose when you create new versions. The other way to do it is to release every time a new commit reaches the main branch, and you could even let the pipeline bump the version for you based on the changes.

And I also did a ramp-up on README.md, just because 😬.

Hope you find this useful, and I'm glad to help with other git-related technical stuff!